### PR TITLE
Lobby - personal detail page - view mode layout

### DIFF
--- a/src/front-end/layout/lobby/body/body-left/one-block/four-rows/four-rows.html
+++ b/src/front-end/layout/lobby/body/body-left/one-block/four-rows/four-rows.html
@@ -1,38 +1,37 @@
 <html class="" lang="en">
-	<head>
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css"> -->
-		<link rel="stylesheet" href="../../../../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 220px"></div>
-			<div class="body border">
-				<!-- this is the layout for the body, others should be removed -->
-				<div class="body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
-					<div class="body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;">
-						<div class="row border" style="width: 100%; height: 200px">
-							<div class="item border" style="height: 30px; width: 200px; padding-top: 5px;">
-								<div class="border" style="display: inline-block; width: 30px; height: 30px; float: left"></div>
-								<div class="border" style="display: inline-block; width: 166px; height:30px;"></div>
-							</div>
-							<div class="item border" style="height: 30px; width: 200px; padding-top: 5px;">
-								<div class="border" style="display: inline-block; width: 30px; height: 30px; float: left"></div>
-								<div class="border" style="display: inline-block; width: 166px; height:30px;"></div>
-							</div>
-							<div class="item border" style="height: 30px; width: 200px; padding-top: 5px;">
-								<div class="border" style="display: inline-block; width: 30px; height: 30px; float: left"></div>
-								<div class="border" style="display: inline-block; width: 166px; height:30px;"></div>
-							</div>
-							<hr>
-							<div class="item border" style="height: 30px; width: 200px;">
-								<div class="border" style="display: inline-block; width: 30px; height: 30px; float: left"></div>
-								<div class="border" style="display: inline-block; width: 166px; height:30px;"></div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;">
+                <div class="lobby-row border" style="width: 100%; height: 200px">
+                    <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;">
+                        <div class="border" style="display: inline-block; width: 30px; height: 30px; float: left"></div>
+                        <div class="border" style="display: inline-block; width: 166px; height:30px;"></div>
+                    </div>
+                    <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;">
+                        <div class="border" style="display: inline-block; width: 30px; height: 30px; float: left"></div>
+                        <div class="border" style="display: inline-block; width: 166px; height:30px;"></div>
+                    </div>
+                    <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;">
+                        <div class="border" style="display: inline-block; width: 30px; height: 30px; float: left"></div>
+                        <div class="border" style="display: inline-block; width: 166px; height:30px;"></div>
+                    </div>
+                    <hr>
+                    <div class="lobby-item border" style="height: 30px; width: 200px;">
+                        <div class="border" style="display: inline-block; width: 30px; height: 30px; float: left"></div>
+                        <div class="border" style="display: inline-block; width: 166px; height:30px;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/body/body-left/one-block/one-block.html
+++ b/src/front-end/layout/lobby/body/body-left/one-block/one-block.html
@@ -1,20 +1,20 @@
 <html class="" lang="en">
-	<head>
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css"> -->
-		<link rel="stylesheet" href="../../../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 220px"></div>
-			<div class="body border">
-				<!-- this is the layout for the body, others should be removed -->
-				<div class="body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
-					<div class="body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;">
-						<div class="row border" style="width: 100%; height: 200px"></div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: 100%;">
+                <div class="lobby-row border" style="width: 100%; height: 200px"></div>
+            </div>
+            <div class="lobby-body-right border" style="display: inline-block; margin-left: 10px; width: 766px; height: 100%;"></div>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/body/body-left/two-blocks/four-rows/four-rows.html
+++ b/src/front-end/layout/lobby/body/body-left/two-blocks/four-rows/four-rows.html
@@ -1,78 +1,33 @@
 <html class="" lang="en">
-	<head>
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css"> -->
-		<link rel="stylesheet" href="../../../../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 220px"></div>
-			<div class="body border">
-				<!-- this is the layout for the body, others should be removed -->
-				<div class="body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
-					<div class="body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;">
-						<div class="row border" style="width: 100%; height: 200px"></div>
-						<div class="row border" style="width: 100%; margin-top:10px; height: auto;">
-							<div class="row border" style="width: 100%; height: 148px">
-								<div class="item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
-								<div class="item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
-								<div class="item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
-								<div class="item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
-							</div>
-							<div class="row border" style="width: 100%; height: auto; margin-top:10px;">
-								<div class="item border" style="height: 39px; width: 100%;"></div>
-								<div class="item border" style="height: 39px; width: 100%;"></div>
-								<div class="item border" style="height: 39px; width: 100%;"></div>
-								<div class="item border" style="height: 38px; width: 100%;"></div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;">
+                <div class="lobby-row border" style="width: 100%; height: 200px"></div>
+                <div class="lobby-row border" style="width: 100%; margin-top:10px; height: auto;">
+                    <div class="lobby-inner-row border" style="width: 100%; height: 150px">
+                        <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
+                        <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
+                        <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
+                        <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
+                    </div>
+                    <div class="lobby-inner-row border" style="width: 100%; height: auto; margin-top:10px;">
+                        <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
+                        <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
+                        <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
+                        <div class="lobby-item border" style="height: 30px; width: 200px; padding-top: 5px;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
 </html>
-
-<!-- <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../../layout.css">
-	</head>
-	<body>
-		<div>
-			<div class="header border" style="min-width: 1024px; height: 250px"></div>
-			<div class="body border" style="min-width: 1024px; height: 510px">
-				<div class="body-container border" style="margin: 10px auto; width: 980px; height: 490px;">
-					<div class="body-left border" style="float: left; margin-left: 0; width: 200px; height: auto;">
-						this is the layout for three vertical blocks on the left side of body
-						<div class="row border" style="width: 100%; margin-left: 0px">
-							<div class="inner-block border" style="height: 93px; width: 100%;">
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-							</div>
-							<div class="inner-block border" style="height: 94px; width: 100%;">
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-							</div>
-						</div>
-						<div class="row border" style="height: auto; width: 100%; margin: 10px 0px 0px 0px">
-							<div class="inner-block border" style="height: 125px; width: 100%; margin-left: 0px">
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-								<div class="item border" style="height: 30px; width: 100%;"></div>
-							</div>
-							<div class="inner-block border" style="height: 153px; width: 100%; margin-left: 0px">
-								<div class="item border" style="height: 39px; width: 100%;"></div>
-								<div class="item border" style="height: 39px; width: 100%;"></div>
-								<div class="item border" style="height: 39px; width: 100%;"></div>
-								<div class="item border" style="height: 38px; width: 100%;"></div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
-</html> -->

--- a/src/front-end/layout/lobby/body/body-left/two-blocks/two-blocks.html
+++ b/src/front-end/layout/lobby/body/body-left/two-blocks/two-blocks.html
@@ -1,24 +1,23 @@
 <html class="" lang="en">
-	<head>
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css"> -->
-		<link rel="stylesheet" href="../../../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 220px"></div>
-			<div class="body border">
-				<!-- this is the layout for the body, others should be removed -->
-				<div class="body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
-					<div class="body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;">
-						<div class="row border" style="width: 100%; height: 200px"></div>
-						<div class="row border" style="width: 100%; margin-top:10px; height: auto;">
-							<div class="row border" style="width: 100%; height: 150px"></div>
-							<div class="row border" style="width: 100%; height: auto; margin-top:10px;"></div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;">
+                <div class="lobby-row border" style="width: 100%; height: 200px"></div>
+                <div class="lobby-row border" style="width: 100%; margin-top:10px; height: auto;">
+                    <div class="lobby-inner-row border" style="width: 100%; height: 150px"></div>
+                    <div class="lobby-inner-row border" style="width: 100%; height: auto; margin-top:10px;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/body/body-right/two-rows/expanded-status-box/comment-box/comment-box.html
+++ b/src/front-end/layout/lobby/body/body-right/two-rows/expanded-status-box/comment-box/comment-box.html
@@ -1,59 +1,58 @@
 <html class="" lang="en">
-	<head>
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css"> -->
-		<link rel="stylesheet" href="../../../../../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 220px"></div>
-			<div class="body border">
-				<div class="body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
-					<div class="body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: 100%;"></div>
-					<div class="body-right border" style="display: inline-block; margin-left: 10px; width: 766px;">
-						<!-- this is the layout for body right two rows, others should be removed -->
-						<div class="body-right-top border" style="width: 100%; overflow: hidden">
-							<div class="status-input border" style="height: 30px; width: 100%;"></div>
-							<div class="submit-status border" style="height: 40px; width: 100%; display: none;"></div>
-						</div>
-						<div class="body-right-bottom border" style="width: 100%; margin-top: 10px;">
-							<div class="status-box border" style="width: 100%; overflow: hidden; margin-top: 5px;">
-								<div class="status-box-left border" style="width: 70px; float: left; display: inline-block;">
-									<div class="user-image border" style="width: 60px; height: 60px; margin: 0px 5px;"></div>
-								</div>
-								<div class="status-box-right border" style="width: 692px; display: inline-block;">
-									<div class="line-1 border" style="height: 40px"></div>
-									<div class="line-2 border"></div>
-									<div class="line-3 border" style="overflow: hidden">
-										<div class="image border" style="width: 600px; height: 300px; margin-right: 5px; float: left; display: inline-block;"></div>
-									</div>
-									<div class="line-4 border" style="height: 300px;"></div>
-									<div class="line-5 border" style="height: 50px;"></div>
-									<div class="line-6 border">
-										<div class="comment-line-1 border" style="height: 30px;"></div>
-										<div class="comment-line-2 border" style="overflow: hidden;">
-											<div class="comment-item border" style="margin-bottom: 5px; overflow: hidden;">
-												<div class="comment-item-left border" style="width: 30px; height: 30px; display: inline-block; float: left"></div>
-												<div class="comment-item-right border" style="display: inline-block; margin-left: 5px;">
-													<div class="comment-username border" style="height: 20px;width: 300px"></div>
-													<div class="comment-text border" style="width: 645px;"></div>
-												</div>
-											</div>
-
-										</div>
-										<div class="comment-line-3 border" style="height: 30px; margin-top: 5px;">
-											<div class="comment-item border" style="margin-bottom: 5px; overflow: hidden;">
-												<div class="comment-item-left border" style="width: 30px; height: 30px; display: inline-block; float: left"></div>
-												<div class="comment-item-right border" style="display: inline-block; margin-left: 5px; height: 30px; width: 647px;"></div>
-											</div>
-										</div>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../../../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: 100%;"></div>
+            <div class="lobby-body-right border" style="display: inline-block; margin-left: 10px; width: 766px;">
+                <!-- this is the layout for body right two rows, others should be removed -->
+                <div class="lobby-body-right-top border" style="width: 100%; overflow: hidden">
+                    <div class="lobby-status-input border" style="height: 30px; width: 100%;"></div>
+                    <div class="lobby-submit-status border" style="height: 40px; width: 100%; display: none;"></div>
+                </div>
+                <div class="lobby-body-right-bottom border" style="width: 100%; margin-top: 10px;">
+                    <div class="lobby-status-box border" style="width: 100%; overflow: hidden; margin-top: 5px;">
+                        <div class="lobby-status-box-left border" style="width: 70px; float: left; display: inline-block;">
+                            <div class="lobby-user-image border" style="width: 60px; height: 60px; margin: 0px 5px;"></div>
+                        </div>
+                        <div class="lobby-status-box-right border" style="width: 692px; display: inline-block;">
+                            <div class="lobby-line-1 border" style="height: 40px"></div>
+                            <div class="lobby-line-2 border"></div>
+                            <div class="lobby-line-3 border" style="overflow: hidden">
+                                <div class="lobby-image border" style="width: 600px; height: 300px; margin-right: 5px; float: left; display: inline-block;"></div>
+                            </div>
+                            <div class="lobby-line-4 border" style="height: 300px;"></div>
+                            <div class="lobby-line-5 border" style="height: 50px;"></div>
+                            <div class="lobby-line-6 border">
+                                <div class="lobby-comment-line-1 border" style="height: 30px;"></div>
+                                <div class="lobby-comment-line-2 border" style="overflow: hidden;">
+                                    <div class="lobby-comment-item border" style="margin-bottom: 5px; overflow: hidden;">
+                                        <div class="lobby-comment-item-left border" style="width: 30px; height: 30px; display: inline-block; float: left"></div>
+                                        <div class="lobby-comment-item-right border" style="display: inline-block; margin-left: 5px;">
+                                            <div class="lobby-comment-username border" style="height: 20px;width: 300px"></div>
+                                            <div class="lobby-comment-text border" style="width: 645px;"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="lobby-comment-line-3 border" style="height: 30px; margin-top: 5px;">
+                                    <div class="lobby-comment-item border" style="margin-bottom: 5px; overflow: hidden;">
+                                        <div class="lobby-comment-item-left border" style="width: 30px; height: 30px; display: inline-block; float: left"></div>
+                                        <div class="lobby-comment-item-right border" style="display: inline-block; margin-left: 5px; height: 30px; width: 647px;"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/body/body-right/two-rows/expanded-status-box/expanded-status-box.html
+++ b/src/front-end/layout/lobby/body/body-right/two-rows/expanded-status-box/expanded-status-box.html
@@ -1,41 +1,41 @@
 <html class="" lang="en">
-	<head>
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css"> -->
-		<link rel="stylesheet" href="../../../../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 220px"></div>
-			<div class="body border">
-				<div class="body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
-					<div class="body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: 100%;"></div>
-					<div class="body-right border" style="display: inline-block; margin-left: 10px; width: 766px;">
-						<!-- this is the layout for body right two rows, others should be removed -->
-						<div class="body-right-top border" style="width: 100%; overflow: hidden">
-							<div class="status-input border" style="height: 30px; width: 100%;"></div>
-							<div class="submit-status border" style="height: 40px; width: 100%; display: none;"></div>
-						</div>
-						<div class="body-right-bottom border" style="width: 100%; margin-top: 10px;">
-							<div class="status-box border" style="width: 100%; overflow: hidden; margin-top: 5px;">
-								<div class="status-box-left border" style="width: 70px; float: left; display: inline-block;">
-									<div class="user-image border" style="width: 60px; height: 60px; margin: 0px 5px;"></div>
-								</div>
-								<div class="status-box-right border" style="width: 692px; display: inline-block;">
-									<div class="line-1 border" style="height: 40px"></div>
-									<div class="line-2 border"></div>
-									<div class="line-3 border" style="overflow: hidden">
-										<div class="image border" style="width: 600px; height: 300px; margin-right: 5px; float: left; display: inline-block;"></div>
-									</div>
-									<div class="line-4 border" style="height: 300px;"></div>
-									<div class="line-5 border" style="height: 50px;"></div>
-									<div class="line-6 border"></div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: 100%;"></div>
+            <div class="lobby-body-right border" style="display: inline-block; margin-left: 10px; width: 766px;">
+                <!-- this is the layout for body right two rows, others should be removed -->
+                <div class="lobby-body-right-top border" style="width: 100%; overflow: hidden">
+                    <div class="lobby-status-input border" style="height: 30px; width: 100%;"></div>
+                    <div class="lobby-submit-status border" style="height: 40px; width: 100%; display: none;"></div>
+                </div>
+                <div class="lobby-body-right-bottom border" style="width: 100%; margin-top: 10px;">
+                    <div class="lobby-status-box border" style="width: 100%; overflow: hidden; margin-top: 5px;">
+                        <div class="lobby-status-box-left border" style="width: 70px; float: left; display: inline-block;">
+                            <div class="lobby-user-image border" style="width: 60px; height: 60px; margin: 0px 5px;"></div>
+                        </div>
+                        <div class="lobby-status-box-right border" style="width: 692px; display: inline-block;">
+                            <div class="lobby-line-1 border" style="height: 40px"></div>
+                            <div class="lobby-line-2 border"></div>
+                            <div class="lobby-line-3 border" style="overflow: hidden">
+                                <div class="lobby-image border" style="width: 600px; height: 300px; margin-right: 5px; float: left; display: inline-block;"></div>
+                            </div>
+                            <div class="lobby-line-4 border" style="height: 300px;"></div>
+                            <div class="lobby-line-5 border" style="height: 50px;"></div>
+                            <div class="lobby-line-6 border"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/body/body.html
+++ b/src/front-end/layout/lobby/body/body.html
@@ -1,19 +1,18 @@
 <html class="" lang="en">
-	<head>
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css"> -->
-		<link rel="stylesheet" href="../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 220px"></div>
-			<div class="body border">
-				<!-- this is the layout for the body, others should be removed -->
-				<div class="body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
-					<div class="body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: 100%;"></div>
-					<div class="body-right border" style="display: inline-block; margin-left: 10px; width: 766px; height: 100%;"></div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;"></div>
+            <div class="lobby-body-right border" style="display: inline-block; margin-left: 10px; width: 766px; height: 100%;"></div>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/cover/avatar/avatar.html
+++ b/src/front-end/layout/lobby/cover/avatar/avatar.html
@@ -1,18 +1,19 @@
 <html class="" lang="en">
-	<head>
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css"> -->
-		<link rel="stylesheet" href="../../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 250px; width: 980px; margin: auto;">
-				<div class="cover border" style="height: 205px;"></div>
-				<div class="avatar-container border" style="height: 160px; margin-top: -118px;">
-					<div class="avatar border" style="margin-left: 10px; width: 160px; height: 160px; float: left;"></div>
-					<div class="username border" style="display: inline-block; width:250px; height: 43px;margin-top: 116px"></div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 250px; width: 980px; margin: auto;">
+        <div class="lobby-cover border" style="height: 205px;"></div>
+        <div class="lobby-avatar-container border" style="height: 160px; margin-top: -118px;">
+            <div class="lobby-avatar border" style="margin-left: 10px; width: 160px; height: 160px; float: left;"></div>
+            <div class="lobby-username border" style="display: inline-block; width:250px; height: 43px;margin-top: 116px"></div>
+        </div>
+    </div>
+    <div class="lobby-body border"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/cover/cover.html
+++ b/src/front-end/layout/lobby/cover/cover.html
@@ -1,15 +1,15 @@
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-		<link rel="stylesheet" href="../layout.css">
-	</head>
-	<body>
-		<!-- this is the layout only for header, body should be removed later -->
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 250px; width: 980px; margin: auto;">
-				<div class="cover border" style="height: 205px;"></div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 250px; width: 980px; margin: auto;">
+        <div class="lobby-cover border" style="height: 205px;"></div>
+    </div>
+    <div class="lobby-body border"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/header/header.html
+++ b/src/front-end/layout/lobby/header/header.html
@@ -1,17 +1,17 @@
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-		<link rel="stylesheet" href="../layout.css">
-	</head>
-	<body>
-		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px; text-align: center;">
-				<div class="user-photo border" style="width: 60px; height: 60px; display: inline-block; float: left"></div>
-				<div class="search-bar border" style="margin: 5px 0px; width: 500px; height: 50px; display: inline-block;">
-
-				</div>
-				<div class="logout border" style="width: 60px; height: 58px; display: inline-block; float: right"></div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;">
+        <div class="user-photo border" style="width: 60px; height: 60px; display: inline-block; float: left"></div>
+        <div class="search-bar border" style="margin: 5px 0px; width: 500px; height: 50px; display: inline-block;"></div>
+        <div class="logout border" style="width: 60px; height: 58px; display: inline-block; float: right"></div>
+    </div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/lobby/lobby.html
+++ b/src/front-end/layout/lobby/lobby.html
@@ -5,9 +5,9 @@
 	</head>
 	<body>
 		<div style="min-width: 1024px; min-height: 768px;">
-			<div class="header border" style="height: 60px;"></div>
-			<div class="cover-container border" style="height: 220px"></div>
-			<div class="body border"></div>
+			<div class="lobby-header border" style="height: 60px;"></div>
+			<div class="lobby-cover-container border" style="height: 220px"></div>
+			<div class="lobby-body border"></div>
 		</div>
 	</body>
 </html>

--- a/src/front-end/layout/login/body/body-left/body-left-bottom/four-cells-layout/body-left-bottom.html
+++ b/src/front-end/layout/login/body/body-left/body-left-bottom/four-cells-layout/body-left-bottom.html
@@ -1,28 +1,34 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../../../layout.css">
-	</head>
-	<body>
-		<!-- body-container, body-left, body-left-container and body-left-bottom should be removed late, this div should be included inside main layout -->
-		<div class="body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
-			<div class="body-left border" style="width:586px;height:100%;display: inline-block;">
-				<div class="body-left-container border" style="float:right; width: 80%;height:100%;">
-					<!-- margin-top should be removed-->
-					<div class="body-left-bottom border" style="margin-top: 102px;height: 474px">
-						<div class="body-left-bottom-row border" style="height: 200px;width: 100%;">
-								<div class="body-left-bottom-col border" style="display:inline-block;float:left;height: 100%;width: 230px;"></div>
-								<div class="vertical-separator" style="display:inline-block;float:left;height: 100%;width: 2px;"></div>
-								<div class="body-left-bottom-col border" style="display:inline-block;float:left;height: 100%;width: 230px;"></div>
-						</div>
-						<div class="body-left-bottom-row border" style="height: 200px;width: 100%;">
-								<div class="body-left-bottom-col border" style="display:inline-block;float:left;height: 100%;width: 230px;"></div>
-								<div class="vertical-separator" style="display:inline-block;float:left;height: 100%;width: 2px;"></div>
-								<div class="body-left-bottom-col border" style="display:inline-block;float:left;height: 100%;width: 230px;"></div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../../layout.css">
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px">
+        <div class="login-body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
+            <div class="login-body-left border" style="width:586px;height:100%;display: inline-block;">
+                <div class="login-body-left-container border" style="float:right; width: 80%;height:100%;">
+                    <div class="login-body-left-top-box border" style="height: 100px"></div>
+                    <div class="login-body-left-bottom-box border" style="height: 474px">
+                        <div class="login-body-left-bottom-row border" style="height: 200px;width: 100%;">
+                            <div class="body-left-bottom-col border" style="display:inline-block;float:left;height: 100%;width: 230px;"></div>
+                            <div class="vertical-separator" style="display:inline-block;float:left;height: 100%;width: 1px;"></div>
+                            <div class="body-left-bottom-col border" style="display:inline-block;float:left;height: 100%;width: 230px;"></div>
+                        </div>
+                        <div class="login-body-left-bottom-row border" style="height: 200px;width: 100%;">
+                            <div class="body-left-bottom-col border" style="display:inline-block;float:left;height: 100%;width: 230px;"></div>
+                            <div class="vertical-separator" style="display:inline-block;float:left;height: 100%;width: 1px;"></div>
+                            <div class="body-left-bottom-col border" style="display:inline-block;float:left;height: 100%;width: 230px;"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="login-body-right border" style="float:right;width:390px;height:100%; display: inline-block;"></div>
+        </div>
+    </div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/body/body-left/body-left-top/body-left-top.html
+++ b/src/front-end/layout/login/body/body-left/body-left-top/body-left-top.html
@@ -1,18 +1,25 @@
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../../layout.css">
-	</head>
-	<body>
-		<!-- body-container and body-left should be removed late, this div should be included inside main layout -->
-		<div class="body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
-			<div class="body-left border" style="width:586px;height:100%;display: inline-block;">
-				<div class="body-left-container border" style="float:right; width: 80%;height:100%;">
-					<div class="body-left-top border" style="height: 100px">
-						<div class="body-left-top-inner border" style="margin: 15px 30px; height:70px;display: flex; align-items: center; justify-content: center;">
-					</div>
-					<div class="body-left-bottom border" style="height: 474px"></div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../layout.css">
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px">
+        <div class="login-body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
+            <div class="login-body-left border" style="width:586px;height:100%;display: inline-block;">
+                <div class="login-body-left-container border" style="float:right; width: 80%;height:100%;">
+                    <div class="login-body-left-top-box border" style="height: 100px">
+                        <div class="login-body-left-top-inner border" style="margin: 15px 30px; height:70px;display: flex; align-items: center; justify-content: center;"></div>
+                    </div>
+                    <div class="login-body-left-bottom-box border" style="height: 474px"></div>
+                </div>
+            </div>
+            <div class="login-body-right border" style="float:right;width:390px;height:100%; display: inline-block;"></div>
+        </div>
+    </div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/body/body-left/body-left.html
+++ b/src/front-end/layout/login/body/body-left/body-left.html
@@ -1,17 +1,23 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../layout.css">
-	</head>
-	<body>
-		<!-- body-container and body-left should be removed late, this div should be included inside main layout -->
-		<div class="body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
-			<div class="body-left border" style="width:586px;height:100%;display: inline-block;">
-				<div class="body-left-container border" style="float:right; width: 80%;height:100%;">
-					<div class="body-left-top border" style="height: 100px"></div>
-					<div class="body-left-bottom border" style="height: 474px"></div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../layout.css">
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px">
+        <div class="login-body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
+            <div class="login-body-left border" style="width:586px;height:100%;display: inline-block;">
+                <div class="login-body-left-container border" style="float:right; width: 80%;height:100%;">
+                    <div class="login-body-left-top-box border" style="height: 100px"></div>
+                    <div class="login-body-left-bottom-box border" style="height: 474px"></div>
+                </div>
+            </div>
+            <div class="login-body-right border" style="float:right;width:390px;height:100%; display: inline-block;"></div>
+        </div>
+    </div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/body/body-right/body-right-bottom/five-rows/body-right-bottom.html
+++ b/src/front-end/layout/login/body/body-right/body-right-bottom/five-rows/body-right-bottom.html
@@ -1,33 +1,39 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../../../layout.css">
-	</head>
-	<body>
-		<!-- body-container, body-right, body-right-container, body-right-top and body-right-bottom should be removed late, this div should be included inside main layout -->
-		<div class="body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
-			<div class="body-right border" style="float:right;width:390px;height:100%; display: inline-block;">
-				<div class="body-right-container border" style="clear:both ;  width: 80%;height:100%;">
-					<div class="body-right-top border" style="height: 100px"></div>
-					<div class="body-right-bottom border" style="height: 474px">
-						<div class="body-right-bottom-row border" style="height: 70px;width: 100%;">
-								<div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
-						</div>
-						<div class="body-right-bottom-row border" style="height: 70px;width: 100%;">
-								<div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
-						</div>
-						<div class="body-right-bottom-row border" style="height: 70px;width: 100%;">
-								<div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
-						</div>
-						<div class="body-right-bottom-row border" style="height: 120px;width: 100%;">
-								<div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
-						</div>
-						<div class="body-right-bottom-row border" style="height: 70px;width: 100%;">
-								<div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../layout.css">
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px">
+        <div class="login-body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
+            <div class="login-body-left border" style="width:586px;height:100%;display: inline-block;"></div>
+            <div class="login-body-right border" style="float:right;width:390px;height:100%; display: inline-block;">
+                <div class="login-body-right-container border" style="clear:both; width: 80%; height:100%;">
+                    <div class="login-body-right-top-box border" style="height: 100px"></div>
+                    <div class="login-body-right-bottom-box border" style="height: 474px">
+                        <div class="body-right-bottom-row border" style="height: 70px;width: 100%;">
+                            <div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
+                        </div>
+                        <div class="body-right-bottom-row border" style="height: 70px;width: 100%;">
+                            <div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
+                        </div>
+                        <div class="body-right-bottom-row border" style="height: 70px;width: 100%;">
+                            <div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
+                        </div>
+                        <div class="body-right-bottom-row border" style="height: 120px;width: 100%;">
+                            <div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
+                        </div>
+                        <div class="body-right-bottom-row border" style="height: 70px;width: 100%;">
+                            <div class="body-right-bottom-col border" style="height: 100%;width: 100%;"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/body/body-right/body-right-top/body-right-top.html
+++ b/src/front-end/layout/login/body/body-right/body-right-top/body-right-top.html
@@ -1,19 +1,25 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../../layout.css">
-	</head>
-	<body>
-		<!-- body-container, body-right, body-right-container, body-right-top and body-right-bottom should be removed late, this div should be included inside main layout -->
-		<div class="body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
-			<div class="body-right border" style="float:right;width:390px;height:100%; display: inline-block;">
-				<div class="body-right-container border" style="clear:both ;  width: 80%;height:100%;">
-					<div class="body-right-top border" style="height: 100px">
-						<div class="body-right-top-inner border" style="margin: 15px; height:70px;display: flex; align-items: center; justify-content: center;"></div>
-					</div>
-					<div class="body-right-bottom border" style="height: 474px"></div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../layout.css">
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px">
+        <div class="login-body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
+            <div class="login-body-left border" style="width:586px;height:100%;display: inline-block;"></div>
+            <div class="login-body-right border" style="float:right;width:390px;height:100%; display: inline-block;">
+                <div class="login-body-right-container border" style="clear:both; width: 80%; height:100%;">
+                    <div class="login-body-right-top-box border" style="height: 100px">
+                        <div class="body-right-top-inner border" style="margin: 15px; height:70px;display: flex; align-items: center; justify-content: center;"></div>
+                    </div>
+                    <div class="login-body-right-bottom-box border" style="height: 474px"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/body/body-right/body-right.html
+++ b/src/front-end/layout/login/body/body-right/body-right.html
@@ -1,17 +1,23 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../../../layout.css">
-	</head>
-	<body>
-		<!-- body-container, body-right, body-right-container, body-right-top and body-right-bottom should be removed late, this div should be included inside main layout -->
-		<div class="body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
-			<div class="body-right border" style="float:right;width:390px;height:100%; display: inline-block;">
-				<div class="body-right-container border" style="clear:both ;  width: 80%;height:100%;">
-					<div class="body-right-top border" style="height: 100px"></div>
-					<div class="body-right-bottom border" style="height: 474px"></div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../layout.css">
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px">
+        <div class="login-body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
+            <div class="login-body-left border" style="width:586px;height:100%;display: inline-block;"></div>
+            <div class="login-body-right border" style="float:right;width:390px;height:100%; display: inline-block;">
+                <div class="login-body-right-container border" style="clear:both; width: 80%; height:100%;">
+                    <div class="login-body-right-top-box border" style="height: 100px"></div>
+                    <div class="login-body-right-bottom-box border" style="height: 474px"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/body/body.html
+++ b/src/front-end/layout/login/body/body.html
@@ -1,15 +1,18 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../layout.css">
-		
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css"> -->
-	</head>
-	<body>
-		<!-- height:580px should be removed late, this div should be included inside main layout -->
-		<div class="body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
-			<div class="body-left border" style="width:586px;height:100%;display: inline-block;"></div>
-			<div class="body-right border" style="float:right;width:390px;height:100%; display: inline-block;"></div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../layout.css">
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px">
+        <div class="login-body-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 580px;">
+            <div class="login-body-left border" style="width:586px;height:100%;display: inline-block;"></div>
+            <div class="login-body-right border" style="float:right;width:390px;height:100%; display: inline-block;"></div>
+        </div>
+    </div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/footer/footer.html
+++ b/src/front-end/layout/login/footer/footer.html
@@ -1,12 +1,19 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../layout.css">
-	</head>
-	<body>
-		<!-- margin-top: 60px; height:80px should be removed late, this div should be included inside main layout -->
-		<div class="footer-container border" style="margin-left: auto; margin-right: auto; margin-top:660px;width: 980px; height: 100px;">
-			<div class="footer-info border" style="margin-left:auto; margin-right:auto;width:300px;height:100%;"></div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../layout.css">
+
+    <!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css"> -->
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px"></div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px">
+        <div class="login-footer-container border" style="margin-left: auto; margin-right: auto; margin-top:660px;width: 980px; height: 100px;">
+            <div class="login-footer-info border" style="margin-left:auto; margin-right:auto;width:300px;height:100%;"></div>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/footer/two-rows/footer.html
+++ b/src/front-end/layout/login/footer/two-rows/footer.html
@@ -1,21 +1,26 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../layout.css">
-	</head>
-	<body>
-		<!-- margin-top: 60px; height:80px should be removed late, this div should be included inside main layout -->
-		<div class="footer-container border" style="margin-left: auto; margin-right: auto; margin-top:660px;width: 980px; height: 100px;">
-			<div class="footer-info border" style="margin-left:auto; margin-right:auto;width:300px;height:100%;">
-				<div class="footer-row border" style="height: 48px;width: 100%;">
-						<div class="footer-col border" style="display:inline-block;float:left;height: 100%;width: 98px; text-align: center"></div>
-						<div class="footer-col border" style="display:inline-block;float:left;height: 100%;width: 98px; text-align: center"></div>
-						<div class="footer-col border" style="display:inline-block;float:left;height: 100%;width: 98px; text-align: center"></div>
-				</div>
-				<div class="footer-row border" style="height: 48px;width: 100%;">
-						<div class="footer-col border" style="display:inline-block;float:left;height: 100%;width: 100%;"></div>
-				</div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../layout.css">
+</head>
+<body>
+<div>
+    <!--<div class="login-header border" style="min-width: 1024px; height: 80px"></div>-->
+    <!--<div class="login-body border" style="min-width: 1024px; height: 580px"></div>-->
+    <div class="login-footer border" style="min-width: 1024px; height: 100px">
+        <div class="login-footer-container border" style="margin-left: auto; margin-right: auto; margin-top:660px;width: 980px; height: 100px;">
+            <div class="login-footer-info border" style="margin-left:auto; margin-right:auto;width:300px;height:100%;">
+                <div class="login-footer-row border" style="height: 48px;width: 100%;">
+                    <div class="footer-col border" style="display:inline-block;float:left;height: 100%;width: 98px; text-align: center"></div>
+                    <div class="footer-col border" style="display:inline-block;float:left;height: 100%;width: 98px; text-align: center"></div>
+                    <div class="footer-col border" style="display:inline-block;float:left;height: 100%;width: 98px; text-align: center"></div>
+                </div>
+                <div class="footer-row border" style="height: 48px;width: 100%;">
+                    <div class="footer-col border" style="display:inline-block;float:left;height: 100%;width: 100%;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/header/header.html
+++ b/src/front-end/layout/login/header/header.html
@@ -1,15 +1,20 @@
-
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../layout.css">
-		
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css"> -->
-	</head>
-	<body>
-		<!-- height:80px should be removed late, this div should be included inside main layout -->
-		<div class="header-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 80px;">
-			<div class="header-logo border" style="width:100px;height:100%;display: inline-block;"></div>
-			<div class="header-input-box border" style="float:right;width:600px;height:100%; display: inline-block;"></div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../layout.css">
+
+    <!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css"> -->
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px">
+        <div class="login-header-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 80px;">
+            <div class="login-header-logo-box border" style="width:100px;height:100%;display: inline-block;"></div>
+            <div class="login-header-input-box border" style="float:right;width:600px;height:100%; display: inline-block;"></div>
+        </div>
+    </div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px"></div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/header/login-input/login-input.html
+++ b/src/front-end/layout/login/header/login-input/login-input.html
@@ -1,20 +1,24 @@
 <html class="" lang="en">
-	<head>
-		<link rel="stylesheet" href="../../layout.css">
-		
-		<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css"> -->
-	</head>
-	<body>
-		<!-- the layout (header-conatiner, header-logo and header-input-box) should be removed late, only the elements should be used -->
-		<div class="header-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 80px;">
-			<div class="header-logo border" style="width:100px;height:100%;display: inline-block;">
-				<!-- logo layout -->
-			</div>
-			<div class="header-input-box border" style="float:right;width:600px;height:100%; display: inline-block;">
-				<div style="height:100%; float: left; width:248px;display:inline-block;" class="username border"></div>
-				<div style="height:100%; float: left; width:246px;display:inline-block;" class="password border"></div>
-				<div style="height:100%; width:100px;display:inline-block;" class="submit border"></div>
-			</div>
-		</div>
-	</body>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../layout.css">
+
+    <!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css"> -->
+</head>
+<body>
+<div>
+    <div class="login-header border" style="min-width: 1024px; height: 80px">
+        <div class="login-header-container border" style="margin-left: auto; margin-right: auto; width: 980px; height: 80px;">
+            <div class="login-header-logo-box border" style="width:100px;height:100%;display: inline-block;"></div>
+            <div class="login-header-input-box border" style="float:right;width:600px;height:100%; display: inline-block;">
+                <div style="height:100%; float: left; width:248px;display:inline-block;" class="login-username border"></div>
+                <div style="height:100%; float: left; width:246px;display:inline-block;" class="login-password border"></div>
+                <div style="height:100%; width:104px;display:inline-block;" class="login-submit border"></div>
+            </div>
+        </div>
+    </div>
+    <div class="login-body border" style="min-width: 1024px; height: 580px"></div>
+    <div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
+</div>
+</body>
 </html>

--- a/src/front-end/layout/login/login.html
+++ b/src/front-end/layout/login/login.html
@@ -7,9 +7,9 @@
 	</head>
 	<body>
 		<div>
-			<div class="header border" style="min-width: 1024px; height: 80px"></div>
-			<div class="body border" style="min-width: 1024px; height: 580px"></div>
-			<div class="footer border" style="min-width: 1024px; height: 100px"></div>
+			<div class="login-header border" style="min-width: 1024px; height: 80px"></div>
+			<div class="login-body border" style="min-width: 1024px; height: 580px"></div>
+			<div class="login-footer border" style="min-width: 1024px; height: 100px"></div>
 		</div>
 	</body>
 </html>

--- a/src/front-end/layout/personDetail/layout.css
+++ b/src/front-end/layout/personDetail/layout.css
@@ -1,0 +1,22 @@
+.border {
+	border: 1px solid #000000;
+}
+
+.border-top {
+	border-top: 1px solid #000000;
+}
+
+
+.border-left  {
+	border-left: 1px solid #000000;
+}
+
+
+.border-bottom {
+	border-bottom: 1px solid #000000;
+}
+
+
+.border-right {
+	border-right: 1px solid #000000;
+}

--- a/src/front-end/layout/personDetail/personDetail-left/four-rows/four-rows.html
+++ b/src/front-end/layout/personDetail/personDetail-left/four-rows/four-rows.html
@@ -1,0 +1,32 @@
+<html class="" lang="en">
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden; height: auto;">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;"></div>
+            <div class="lobby-body-right border" style="display: inline-block; margin-left: 10px; width: 766px; height: auto;">
+                <div class="person-detail-inner-left border" style="width: 381px; height: auto; display: inline-block; float: left;">
+                    <!--this is the layout of person detail inner left-->
+                    <div class="person-detail-row border" style="overflow: hidden; padding: 5px;">
+                        <div class="person-detail-avatar border" style="height: 275px; margin-bottom: 5px;"></div>
+                        <div class="person-detail-avatar-list border" style="height: 55px;"></div>
+                    </div>
+                    <div class="person-detail-row border" style="height: 40px;"></div>
+                    <div class="person-detail-row border" style="overflow: hidden; padding: 5px;">
+                        <div class="person-detail-calendar border" style="height: 170px;"></div>
+                    </div>
+                    <div class="person-detail-row border" style="overflow: hidden; padding: 5px;"></div>
+                </div>
+                <div class="person-detail-inner-right border" style="width: 381px; height: auto; display: inline-block; float: left;"></div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/front-end/layout/personDetail/personDetail-right/nine-rows/nine-rows.html
+++ b/src/front-end/layout/personDetail/personDetail-right/nine-rows/nine-rows.html
@@ -1,0 +1,43 @@
+<html class="" lang="en">
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px; overflow: hidden;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden; height: auto;">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;"></div>
+            <div class="lobby-body-right border" style="display: inline-block; margin-left: 10px; width: 766px; height: auto;">
+                <div class="person-detail-inner-left border" style="width: 381px; height: auto; display: inline-block; float: left;"></div>
+                <div class="person-detail-inner-right border" style="width: 381px; height: auto; overflow: hidden; display: inline-block; float: left;">
+                    <div class="person-detail-inner-left border" style="width: 381px; height: auto; display: inline-block; float: left;">
+                    </div>
+                    <!--this is the layout of person detail page, inner-right part-->
+                    <div class="person-detail-inner-right border" style="width: 381px; height: auto; display: inline-block; float: left;">
+                        <div class="person-detail-name-box border" style="height: 50px;"></div>
+                        <div class="person-detail-age-box border" style="height: 50px;"></div>
+                        <div class="person-detail-occupation-box border" style="height: 50px;"></div>
+                        <div class="person-detail-dob-box border" style="height: 50px;"></div>
+                        <div class="person-detail-nationality-box border" style="height: 50px;"></div>
+                        <div class="person-detail-group-box border" style="height: 50px;"></div>
+                        <div class="person-detail-acceptable-options-box border" style="height: auto; overflow: hidden;">
+                            <div class="person-detail-incall-box border" style="height: 80px;"></div>
+                            <div class="person-detail-outcall-box border" style="height: 50px;"></div>
+                            <div class="person-detail-overnight-box border" style="height: 50px;"></div>
+                            <div class="person-detail-sm-box border" style="height: 50px;"></div>
+                            <div class="person-detail-uniform-box border" style="height: 50px;"></div>
+                            <div class="person-detail-btn-add border" style="height: 50px;"></div>
+                        </div>
+                        <div class="person-detail-acceptable-client-type-box border" style="height: auto; overflow: hidden;"></div>
+                        <div class="person-detail-control-box border"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/front-end/layout/personDetail/personDetail-right/nine-rows/view-mode/view-mode.html
+++ b/src/front-end/layout/personDetail/personDetail-right/nine-rows/view-mode/view-mode.html
@@ -1,0 +1,95 @@
+<html class="" lang="en">
+<head>
+    <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="../../../layout.css">
+</head>
+<body>
+<div style="min-width: 1024px; min-height: 768px; overflow: hidden;">
+    <div class="lobby-header border" style="height: 60px;"></div>
+    <div class="lobby-cover-container border" style="height: 220px"></div>
+    <div class="lobby-body border">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden; height: auto;">
+            <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;"></div>
+            <div class="lobby-body-right border" style="display: inline-block; margin-left: 10px; width: 766px; height: auto;">
+                <div class="person-detail-inner-left border" style="width: 381px; height: auto; display: inline-block; float: left;"></div>
+                <div class="person-detail-inner-right border" style="width: 381px; height: auto; overflow: hidden; display: inline-block; float: left;">
+                    <div class="person-detail-inner-left border" style="width: 381px; height: auto; display: inline-block; float: left;">
+                    </div>
+                    <!--this is the layout of person detail page, inner-right part-->
+                    <div class="person-detail-inner-right border" style="width: 381px; height: auto; display: inline-block; float: left; padding-left: 20px;">
+                        <div class="person-detail-name-box border" style="height: 50px; width: 360px;">
+                            <div class="person-detail-item-title border" style="display: inline-block; float: left; width: 100px; height: 50px;"></div>
+                            <div class="person-detail-item-content border" style="display: inline-block; float: left; height: 50px; margin-left: 10px;"></div>
+                            <div class="person-detail-item-edit border" style="display: inline-block; float: right; width: 50px; height: 50px;"></div>
+                        </div>
+                        <div class="person-detail-age-box border" style="height: 50px; width: 360px;">
+                            <div class="person-detail-item-title border" style="display: inline-block; float: left; width: 100px; height: 50px;"></div>
+                            <div class="person-detail-item-content border" style="display: inline-block; float: left; height: 50px; margin-left: 10px;"></div>
+                            <div class="person-detail-item-edit border" style="display: inline-block; float: right; width: 50px; height: 50px;"></div>
+                        </div>
+                        <div class="person-detail-occupation-box border" style="height: 50px; width: 360px;">
+                            <div class="person-detail-item-title border" style="display: inline-block; float: left; width: 100px; height: 50px;"></div>
+                            <div class="person-detail-item-content border" style="display: inline-block; float: left; height: 50px; margin-left: 10px;"></div>
+                            <div class="person-detail-item-edit border" style="display: inline-block; float: right; width: 50px; height: 50px;"></div>
+                        </div>
+                        <div class="person-detail-dob-box border" style="height: 50px; width: 360px;">
+                            <div class="person-detail-item-title border" style="display: inline-block; float: left; width: 100px; height: 50px;"></div>
+                            <div class="person-detail-item-content border" style="display: inline-block; float: left; height: 50px; margin-left: 10px;"></div>
+                            <div class="person-detail-item-edit border" style="display: inline-block; float: right; width: 50px; height: 50px;"></div>
+                        </div>
+                        <div class="person-detail-nationality-box border" style="height: 50px; width: 360px;">
+                            <div class="person-detail-item-title border" style="display: inline-block; float: left; width: 100px; height: 50px;"></div>
+                            <div class="person-detail-item-content border" style="display: inline-block; float: left; height: 50px; margin-left: 10px;"></div>
+                            <div class="person-detail-item-edit border" style="display: inline-block; float: right; width: 50px; height: 50px;"></div>
+                        </div>
+                        <div class="person-detail-group-box border" style="height: 51px; width: 360px;">
+                            <div class="person-detail-item-title border" style="display: inline-block; float: left; width: 100px; height: 50px;"></div>
+                            <div class="person-detail-item-content border" style="display: inline-block; float: left; height: 50px; margin-left: 10px;"></div>
+                            <div class="person-detail-item-edit border" style="display: inline-block; float: right; width: 50px; height: 50px;"></div>
+                        </div>
+                        <div class="person-detail-acceptable-options-box border" style="height: auto; overflow: hidden; width: 360px;">
+                            <div class="person-detail-incall-box border" style="height: 90px;">
+                                <div class="person-detail-item-title border" style="height: 40px;"></div>
+                                <div class="person-detail-option-item border" style="height: 49px;">
+                                    <div class="person-detail-checkbox border" style="width: 30px; display: inline-block; float: left; height: 48px; margin-left: 30px;"></div>
+                                    <div class="person-detail-option-title border" style="display: inline-block; float: left; height: 48px; width: 100px;"></div>
+                                    <div class="person-detail-option-info border" style="display: inline-block; float: right; height: 48px;"></div>
+                                    <div class="person-detail-option-edit border" style="display: inline-block; float: right; height: 48px; width: 50px;"></div>
+                                </div>
+                            </div>
+                            <div class="person-detail-outcall-box border" style="height: 50px;">
+                                <div class="person-detail-checkbox border" style="width: 30px; clear: both; display: inline-block; float: left; height: 48px; margin-left: 31px;"></div>
+                                <div class="person-detail-option-title border" style="display: inline-block; float: left; height: 48px; width: 100px;"></div>
+                                <div class="person-detail-option-info border" style="display: inline-block; float: right; height: 48px;"></div>
+                                <div class="person-detail-option-edit border" style="display: inline-block; float: right; height: 48px; width: 50px;"></div>
+                            </div>
+                            <div class="person-detail-overnight-box border" style="height: 50px;">
+                                <div class="person-detail-checkbox border" style="width: 30px; clear: both; display: inline-block; float: left; height: 48px; margin-left: 31px;"></div>
+                                <div class="person-detail-option-title border" style="display: inline-block; float: left; height: 48px; width: 100px;"></div>
+                                <div class="person-detail-option-info border" style="display: inline-block; float: right; height: 48px;"></div>
+                                <div class="person-detail-option-edit border" style="display: inline-block; float: right; height: 48px; width: 50px;"></div>
+                            </div>
+                            <div class="person-detail-sm-box border" style="height: 50px;">
+                                <div class="person-detail-checkbox border" style="width: 30px; clear: both; display: inline-block; float: left; height: 48px; margin-left: 31px;"></div>
+                                <div class="person-detail-option-title border" style="display: inline-block; float: left; height: 48px; width: 100px;"></div>
+                                <div class="person-detail-option-info border" style="display: inline-block; float: right; height: 48px;"></div>
+                                <div class="person-detail-option-edit border" style="display: inline-block; float: right; height: 48px; width: 50px;"></div>
+                            </div>
+                            <div class="person-detail-uniform-box border" style="height: 50px;">
+                                <div class="person-detail-checkbox border" style="width: 30px; clear: both; display: inline-block; float: left; height: 48px; margin-left: 31px;"></div>
+                                <div class="person-detail-option-title border" style="display: inline-block; float: left; height: 48px; width: 100px;"></div>
+                                <div class="person-detail-option-info border" style="display: inline-block; float: right; height: 48px;"></div>
+                                <div class="person-detail-option-edit border" style="display: inline-block; float: right; height: 48px; width: 50px;"></div>
+                            </div>
+                            <div class="person-detail-btn-add border" style="height: 50px;"></div>
+                        </div>
+                        <div class="person-detail-acceptable-client-type-box border" style="height: auto; overflow: hidden;"></div>
+                        <div class="person-detail-control-box border"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/front-end/layout/personDetail/personDetail.html
+++ b/src/front-end/layout/personDetail/personDetail.html
@@ -1,21 +1,19 @@
 <html class="" lang="en">
 <head>
     <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">-->
-    <link rel="stylesheet" href="../../../layout.css">
+    <link rel="stylesheet" href="layout.css">
 </head>
 <body>
 <div style="min-width: 1024px; min-height: 768px;">
     <div class="lobby-header border" style="height: 60px;"></div>
     <div class="lobby-cover-container border" style="height: 220px"></div>
     <div class="lobby-body border">
-        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden">
+        <div class="lobby-body-container border" style="margin: 10px auto; width: 980px; overflow: hidden; height: auto;">
             <div class="lobby-body-left border" style="float: left; display: inline-block; margin-left: 0; width: 200px; height: auto;"></div>
             <div class="lobby-body-right border" style="display: inline-block; margin-left: 10px; width: 766px; height: 100%;">
-                <div class="lobby-body-right-top border" style="width: 100%; overflow: hidden">
-                    <div class="lobby-status-input border" style="height: 30px; width: 100%;"></div>
-                    <div class="lobby-submit-status border" style="height: 40px; width: 100%; display: none;"></div>
-                </div>
-                <div class="lobby-body-right-bottom border" style="width: 100%; margin-top: 10px;"></div>
+                <!--this is the layout of person detail page, right part-->
+                <div class="person-detail-inner-left border" style="width: 381px; height: auto; display: inline-block; float: left;"></div>
+                <div class="person-detail-inner-right border" style="width: 381px; height: auto; display: inline-block; float: left;"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Changes:
1. Updated the css name conventions.
2. Change view mode layout of the personal detail page.

Note:
1. Personal detail page (right part) is separated into two equal parts. (Left: photos, calendar, and personal brief, Right: Personal information, view mode)
2. The Left Part is separated into four rows: (photo, tools(like or comments), calendar, and brief)
3. The Right Part is separated into nine row: (Name, Age, Occupation, Date of Birth, Nationality, Group, Acceptable options, Acceptable client type, Button Groups: save and cancel).
4. The height of those two parts are auto, expanded by inner elements.
5. The height of each information input block, for example, Name, is 50px;
6. The information input block is separated into three columns: (Title: Name, Info: Apple, Icon: Edit Image).
